### PR TITLE
Update package versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,6 @@
 
     <dependencies>
         <!-- Testing -->
-        
-        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
@@ -23,13 +21,13 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- END Testing -->
-
+        <!-- Logging  -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.6</version>
+            <version>1.7.25</version>
         </dependency>
+
 
         <dependency>
             <groupId>com.github.kevinsawicki</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,19 +14,15 @@
 
     <dependencies>
         <!-- Testing -->
+        
+        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.3.1</version>
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>1.10.19</version>
-            <scope>test</scope>
-        </dependency>
         <!-- END Testing -->
 
         <dependency>
@@ -44,7 +40,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.3.1</version>
+            <version>2.8.5</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Update the versions of the required packages to match, where possible, the version  of the package required in the BlocklyProp repository.

Deprecate junit 4.x and replace it with junit 5.x
